### PR TITLE
Change model in Sample03 to phi4-mini

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Ollama with Phi-3.5",
+    "name": "Ollama with Phi-4 Mini",
     "image": "mcr.microsoft.com/dotnet/sdk:8.0",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
@@ -30,7 +30,7 @@
         32001
     ],
     "postCreateCommand": "",
-    "postStartCommand": "ollama pull phi3.5",
+    "postStartCommand": "ollama pull phi4-mini & docker run --rm -it -p 18888:18888 -p 4317:18889 -d --name ollama-dashboard mcr.microsoft.com/dotnet/ollama-dashboard:8.0.0",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
         32001
     ],
     "postCreateCommand": "",
-    "postStartCommand": "ollama pull phi4-mini & docker run --rm -it -p 18888:18888 -p 4317:18889 -d --name ollama-dashboard mcr.microsoft.com/dotnet/ollama-dashboard:8.0.0",
+    "postStartCommand": "ollama pull phi4-mini",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb",

--- a/src/Sample03/Program.cs
+++ b/src/Sample03/Program.cs
@@ -42,20 +42,20 @@ using Microsoft.SemanticKernel.Plugins.Memory;
 
 var question = "What is Bruno's favourite super hero?";
 Console.WriteLine($"This program will answer the following question: {question}");
-Console.WriteLine("1st approach will be to ask the question directly to the Phi-3 model.");
+Console.WriteLine("1st approach will be to ask the question directly to the Phi-4 mini model.");
 Console.WriteLine("2nd approach will be to add facts to a semantic memory and ask the question again");
 Console.WriteLine("");
 
 // Create a chat completion service
 var builder = Kernel.CreateBuilder();
 builder.AddOpenAIChatCompletion(
-    modelId: "phi3.5",
+    modelId: "phi4-mini",
     endpoint: new Uri("http://localhost:11434"),
     apiKey: "apikey");
 builder.AddLocalTextEmbeddingGeneration();
 Kernel kernel = builder.Build();
 
-Console.WriteLine($"Phi-3 response (no memory).");
+Console.WriteLine($"Phi-4 response (no memory).");
 var response = kernel.InvokePromptStreamingAsync(question);
 await foreach (var result in response)
 {
@@ -68,7 +68,7 @@ Console.WriteLine("==============");
 Console.WriteLine("Press Enter to continue");
 Console.ReadLine();
 Console.WriteLine("==============");
-Console.WriteLine($"Phi-3 response (using semantic memory).");
+Console.WriteLine($"Phi-4 response (using semantic memory).");
 Console.WriteLine("");
 
 // get the embeddings generator service


### PR DESCRIPTION
Suggest changing model from phi3.5 to phi4-mini, since phi3.5 on ollama does not support tools (anymore).

Note: If "dotnet run" results in error saying the model is not found, command "ollama pull phi4-mini" has to be run manually first